### PR TITLE
feature/hgi-10682 | Added filter for URL params for base table because of sentinel value

### DIFF
--- a/tap_dynamics_bc/client.py
+++ b/tap_dynamics_bc/client.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, Optional
 from urllib.parse import parse_qs, urlparse
 
+import pendulum
 import requests
 from hotglue_singer_sdk.helpers.jsonpath import extract_jsonpath
 from hotglue_singer_sdk.streams import RESTStream
@@ -13,6 +14,12 @@ import copy
 from hotglue_singer_sdk.exceptions import FatalAPIError, RetriableAPIError
 import singer
 from singer import StateMessage
+
+# Business Central stamps unmodified records with this sentinel timestamp on
+# system audit fields (e.g. SystemModifiedAt, lastModifiedDateTime). Such
+# records are older than any real start_date and would be dropped by a plain
+# "greater than" replication filter, so initial syncs must explicitly keep them.
+BC_DEFAULT_MODIFIED_SENTINEL = "0001-01-01T00:00:00Z"
 
 
 class dynamicsBcStream(RESTStream):
@@ -249,6 +256,30 @@ class DynamicsBCODataStream(dynamicsBcStream):
         if not chosen_environment:
             raise Exception("No environment with name: " + self.config.get('environment_name', 'Production'))
         return f"https://api.businesscentral.dynamics.com/v2.0/{chosen_environment['aadTenantId']}/{chosen_environment['name']}/ODataV4"
+
+    def _is_initial_sync(self, context: Optional[dict]) -> bool:
+        bookmark_date = self.get_starting_timestamp(context)
+        start_date = self.config.get("start_date")
+        if not bookmark_date or not start_date:
+            return True
+        return bookmark_date == pendulum.parse(start_date)
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        # Unmodified BC records carry the sentinel replication-key value, which
+        # is before start_date and excluded by the default "gt" filter. On the
+        # initial sync, broaden the filter so these records are not lost.
+        if self.replication_key and self._is_initial_sync(context):
+            start_date = self.get_starting_timestamp(context)
+            if start_date:
+                date = start_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+                params["$filter"] = (
+                    f"({self.replication_key} gt {date}) or "
+                    f"({self.replication_key} eq {BC_DEFAULT_MODIFIED_SENTINEL})"
+                )
+        return params
 
     def post_process(self, row: dict, context: Optional[dict] = None) -> Optional[dict]:
         # Header records appear with empty values and should be skipped

--- a/tap_dynamics_bc/client.py
+++ b/tap_dynamics_bc/client.py
@@ -3,7 +3,6 @@
 from typing import Any, Dict, Optional
 from urllib.parse import parse_qs, urlparse
 
-import pendulum
 import requests
 from hotglue_singer_sdk.helpers.jsonpath import extract_jsonpath
 from hotglue_singer_sdk.streams import RESTStream
@@ -258,11 +257,19 @@ class DynamicsBCODataStream(dynamicsBcStream):
         return f"https://api.businesscentral.dynamics.com/v2.0/{chosen_environment['aadTenantId']}/{chosen_environment['name']}/ODataV4"
 
     def _is_initial_sync(self, context: Optional[dict]) -> bool:
-        bookmark_date = self.get_starting_timestamp(context)
-        start_date = self.config.get("start_date")
-        if not bookmark_date or not start_date:
-            return True
-        return bookmark_date == pendulum.parse(start_date)
+        """Return True only for the first sync, when no bookmark exists yet.
+
+        The SDK reports ``get_starting_timestamp`` as ``max(bookmark, start_date)``,
+        so it equals ``start_date`` whenever the bookmark has not advanced past it
+        (e.g. every emitted row carried a replication key at or below start_date,
+        including the BC sentinel). Comparing the starting timestamp against
+        ``start_date`` would therefore keep flagging later runs as initial and leave
+        the broad sentinel filter enabled forever. Instead, detect the initial sync
+        by the absence of a finalized replication-key bookmark in state, which a
+        completed prior sync always writes.
+        """
+        state = self.get_context_state(context)
+        return not state.get("replication_key_value")
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]

--- a/tap_dynamics_bc/streams.py
+++ b/tap_dynamics_bc/streams.py
@@ -7,12 +7,14 @@ import requests
 from hotglue_singer_sdk import typing as th
 from hotglue_singer_sdk.exceptions import FatalAPIError
 import datetime
-from tap_dynamics_bc.client import dynamicsBcStream, DynamicsBCODataStream
+from tap_dynamics_bc.client import (
+    BC_DEFAULT_MODIFIED_SENTINEL,
+    dynamicsBcStream,
+    DynamicsBCODataStream,
+)
 from dateutil.relativedelta import relativedelta
 import pendulum
 import re
-
-BC_DEFAULT_LAST_MODIFIED = "0001-01-01T00:00:00Z"
 
 class CompaniesStream(dynamicsBcStream):
     """Define custom stream."""
@@ -1061,7 +1063,7 @@ class GeneralLedgerEntriesIncrementalStream(GeneralLedgerEntriesStream):
                 # is before start_date and would be excluded by the default gt filter.
                 params["$filter"] = (
                     f"(lastModifiedDateTime gt {date}) or "
-                    f"(lastModifiedDateTime eq {BC_DEFAULT_LAST_MODIFIED})"
+                    f"(lastModifiedDateTime eq {BC_DEFAULT_MODIFIED_SENTINEL})"
                 )
         return params
 


### PR DESCRIPTION
Added the default sentinel value to the URL params for DynamicsBCODataStream so that on full syncs we pull records with default timestamp values. 