### PR TITLE
fix: re-fetch vendor ledger entries by Vendor_No when application upd…

### DIFF
--- a/tap_dynamics_bc/client.py
+++ b/tap_dynamics_bc/client.py
@@ -24,14 +24,21 @@ class dynamicsBcStream(RESTStream):
     @cached_property
     def url_base(self) -> str:
         """Return the API URL root, configurable via tap settings."""
-        url_template = "https://api.businesscentral.dynamics.com/v2.0/{}/api/v2.0"
         env_name = self.config.get("environment_name", "production")
         if "?" in env_name:
             env_name = env_name.split("?")
-            if isinstance(env_name,list):
+            if isinstance(env_name, list):
                 env_name = env_name[0]
-        self.validate_env(env_name)        
-        return url_template.format(env_name)
+        environments = self.get_environments_list()
+        if "value" in environments:
+            chosen = next(
+                (e for e in environments["value"] if e["name"].lower() == env_name.lower()),
+                None,
+            )
+            if chosen:
+                return f"https://api.businesscentral.dynamics.com/v2.0/{chosen['aadTenantId']}/{chosen['name']}/api/v2.0"
+        self.validate_env(env_name)
+        return f"https://api.businesscentral.dynamics.com/v2.0/{env_name}/api/v2.0"
 
     records_jsonpath = "$.value[*]"
     next_page_token_jsonpath = "$.['@odata.nextLink']"

--- a/tap_dynamics_bc/client.py
+++ b/tap_dynamics_bc/client.py
@@ -220,8 +220,12 @@ class DynamicsBCODataStream(dynamicsBcStream):
     @cached_property
     def url_base(self):
         environments = self.get_environments_list()['value']
-        chosen_environment = next((env for env in environments if env['name'] == self.config.get('environment_name', 'Production')), None)
+        env_name = self.config.get('environment_name', 'Production')
+        chosen_environment = next((env for env in environments if env['name'].lower() == env_name.lower()), None)
+        if not chosen_environment and " (" in env_name:
+            env_name_stripped = env_name.split(" (")[0].strip()
+            chosen_environment = next((env for env in environments if env['name'].lower() == env_name_stripped.lower()), None)
         if not chosen_environment:
-            raise Exception("No environment with name: " + self.config.get('environment_name', 'Production'))
+            raise Exception("No environment with name: " + env_name)
         return f"https://api.businesscentral.dynamics.com/v2.0/{chosen_environment['aadTenantId']}/{chosen_environment['name']}/ODataV4"
     

--- a/tap_dynamics_bc/client.py
+++ b/tap_dynamics_bc/client.py
@@ -35,6 +35,13 @@ class dynamicsBcStream(RESTStream):
                 (e for e in environments["value"] if e["name"].lower() == env_name.lower()),
                 None,
             )
+            # Handle "Name (Type)" format that HotGlue UI may produce
+            if not chosen and " (" in env_name:
+                env_name_stripped = env_name.split(" (")[0].strip()
+                chosen = next(
+                    (e for e in environments["value"] if e["name"].lower() == env_name_stripped.lower()),
+                    None,
+                )
             if chosen:
                 return f"https://api.businesscentral.dynamics.com/v2.0/{chosen['aadTenantId']}/{chosen['name']}/api/v2.0"
         self.validate_env(env_name)

--- a/tap_dynamics_bc/client.py
+++ b/tap_dynamics_bc/client.py
@@ -75,7 +75,6 @@ class dynamicsBcStream(RESTStream):
     def http_headers(self) -> dict:
         """Return the http headers needed."""
         headers = {
-            "If-Match": "*",
             "Prefer": f"odata.maxpagesize={self.page_size}"
         }
         

--- a/tap_dynamics_bc/streams.py
+++ b/tap_dynamics_bc/streams.py
@@ -1243,21 +1243,63 @@ class VendorLedgerEntriesStream(DynamicsBCODataStream):
     and objectID = 29
     You can do this in Web Services Modal in Dynamics BC
     """
-    
+
     name = "vendor_ledger_entries"
     path = "/Company('{company_name}')/VendorLedgerEntries"
     primary_keys = ["Document_No", "company_id"]
     parent_stream_type = GeneralLedgerEntriesIncrementalStream
+
+    # Applying a payment/refund/credit memo to an invoice updates the invoice's
+    # own Remaining_Amount in BC without necessarily posting a new GL entry
+    # under the invoice's own Document_No - only the "applying" side's GL
+    # entries get touched. So the Document_No filter below (keyed off whichever
+    # GL entry triggered this sync) can miss the invoice's updated balance
+    # entirely. Once we find ANY vendor ledger entry for the triggering
+    # Document_No, we also re-fetch that vendor's entries by Vendor_No, so
+    # sibling entries closed by the same application are captured too.
+    synced_vendor_nos = set()
 
     def get_url_params(
         self, context: Optional[dict], next_page_token
     ):
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)
-        # Only replace single quotes that are not already doubled
-        escaped_gl_doc_no = re.sub(r"(?<!')'(?!')", "''", context['gl_doc_no'])
-        params.update({"$filter": f"Document_No eq '{escaped_gl_doc_no}'"})
+        vendor_no_filter = getattr(self, "_vendor_no_filter", None)
+        if vendor_no_filter is not None:
+            escaped_vendor_no = re.sub(r"(?<!')'(?!')", "''", vendor_no_filter)
+            params.update({"$filter": f"Vendor_No eq '{escaped_vendor_no}'"})
+        else:
+            # Only replace single quotes that are not already doubled
+            escaped_gl_doc_no = re.sub(r"(?<!')'(?!')", "''", context['gl_doc_no'])
+            params.update({"$filter": f"Document_No eq '{escaped_gl_doc_no}'"})
         return params
+
+    def request_records(self, context: Optional[dict]):
+        self._vendor_no_filter = None
+        seen_keys = set()
+        vendor_nos_to_expand = set()
+
+        for record in super().request_records(context):
+            seen_keys.add((record.get("Entry_No"), record.get("company_id")))
+            vendor_no = record.get("Vendor_No")
+            if vendor_no:
+                vendor_key = (context["company_id"], vendor_no)
+                if vendor_key not in self.synced_vendor_nos:
+                    vendor_nos_to_expand.add(vendor_no)
+            yield record
+
+        try:
+            for vendor_no in vendor_nos_to_expand:
+                self.synced_vendor_nos.add((context["company_id"], vendor_no))
+                self._vendor_no_filter = vendor_no
+                for record in super().request_records(context):
+                    key = (record.get("Entry_No"), record.get("company_id"))
+                    if key in seen_keys:
+                        continue
+                    seen_keys.add(key)
+                    yield record
+        finally:
+            self._vendor_no_filter = None
 
     schema = th.PropertiesList(
         th.Property("Entry_No", th.IntegerType),

--- a/tap_dynamics_bc/streams.py
+++ b/tap_dynamics_bc/streams.py
@@ -1101,14 +1101,27 @@ class DimensionValuesStream(dynamicsBcStream):
     @property
     def url_base(self) -> str:
         """Return the API URL root, configurable via tap settings."""
-        url_template = "https://api.businesscentral.dynamics.com/v2.0/{}/api/microsoft/reportsFinance/beta"
         env_name = self.config.get("environment_name", "production")
         if "?" in env_name:
             env_name = env_name.split("?")
             if isinstance(env_name, list):
                 env_name = env_name[0]
+        environments = self.get_environments_list()
+        if "value" in environments:
+            chosen = next(
+                (e for e in environments["value"] if e["name"].lower() == env_name.lower()),
+                None,
+            )
+            if not chosen and " (" in env_name:
+                env_name_stripped = env_name.split(" (")[0].strip()
+                chosen = next(
+                    (e for e in environments["value"] if e["name"].lower() == env_name_stripped.lower()),
+                    None,
+                )
+            if chosen:
+                return f"https://api.businesscentral.dynamics.com/v2.0/{chosen['aadTenantId']}/{chosen['name']}/api/microsoft/reportsFinance/beta"
         self.validate_env(env_name)
-        return url_template.format(env_name)
+        return f"https://api.businesscentral.dynamics.com/v2.0/{env_name}/api/microsoft/reportsFinance/beta"
 
     schema = th.PropertiesList(
         th.Property("id", th.StringType),


### PR DESCRIPTION

Applying a payment/credit memo to an invoice updates the invoice's own Remaining_Amount in BC, but only the "applying" side's GL entries get a new/touched lastModifiedDateTime - the invoice's own GL entry usually doesn't. Since VendorLedgerEntriesStream only re-fetches by the triggering GL entry's Document_No, the invoice's updated balance was never picked up.

Now, once any vendor ledger entry is found for a triggering Document_No, we also re-fetch that vendor's entries by Vendor_No (deduped per company per run), so sibling entries closed by the same application are captured too.